### PR TITLE
fix(deps): replace deprecated emailjs-com with @emailjs/browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marcaurelebesner.com",
   "private": true,
   "dependencies": {
-    "emailjs-com": "^3.0.0",
+    "@emailjs/browser": "^4.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-scripts": "^5.0.0",

--- a/src/components/contact.jsx
+++ b/src/components/contact.jsx
@@ -1,5 +1,9 @@
 import { useState } from 'react'
-import emailjs from 'emailjs-com'
+import emailjs from '@emailjs/browser'
+
+// `emailjs-com` is deprecated; `@emailjs/browser` requires initializing with
+// a public key instead of accepting it inline with each `sendForm` call.
+emailjs.init({ publicKey: 'user_cO7i9lY0LQpelKqXwQnB7' })
 
 const initialState = {
   name: '',
@@ -20,7 +24,7 @@ export const Contact = (props) => {
     console.log(name, email, message)
     emailjs
       .sendForm(
-        'service_1sb6a0i', 'template_x97lb1h', e.target, 'user_cO7i9lY0LQpelKqXwQnB7'
+        'service_1sb6a0i', 'template_x97lb1h', e.target
       )
       .then(
         (result) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2003,6 +2003,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz#c9c61d9fe5ca5ac664e1153bb0aa0eba1c6d6308"
   integrity sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==
 
+"@emailjs/browser@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@emailjs/browser/-/browser-4.4.1.tgz#ad5684af5a912c0ab415202184845eb3270c4c81"
+  integrity sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==
+
 "@eslint/eslintrc@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.0.tgz#943309d8697c52fc82c076e90c1c74fbbe69dbff"
@@ -4653,11 +4658,6 @@ electron-to-chromium@^1.4.284:
   version "1.4.327"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.327.tgz#288b106518cfed0a60f7de8a0480432a9be45477"
   integrity sha512-DIk2H4g/3ZhjgiABJjVdQvUdMlSABOsjeCm6gmUzIdKxAuFrGiJ8QXMm3i09grZdDBMC/d8MELMrdwYRC0+YHg==
-
-emailjs-com@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/emailjs-com/-/emailjs-com-3.2.0.tgz#a53cb22f1bc433c701c84c53d8b56eefd5ce7111"
-  integrity sha512-Prbz3E1usiAwGjMNYRv6EsJ5c373cX7/AGnZQwOfrpNJrygQJ15+E9OOq4pU8yC977Z5xMetRfc3WmDX6RcjAA==
 
 emittery@^0.10.2:
   version "0.10.2"


### PR DESCRIPTION
## Summary
- Replace the deprecated `emailjs-com` dependency with its official replacement `@emailjs/browser`.
- Update `src/components/contact.jsx` to use the v4 API (`init({ publicKey })` + `sendForm(serviceID, templateID, form)`).

## Why
Renovate flagged `emailjs-com` as deprecated. The package is unmaintained; `@emailjs/browser` is the actively maintained successor with the same EmailJS account/keys.

## Changes
- `package.json`: drop `emailjs-com`, add `@emailjs/browser ^4.4.1`.
- `yarn.lock`: refreshed via `yarn install`.
- `src/components/contact.jsx`: import from `@emailjs/browser` and call `emailjs.init({ publicKey })` once at module load; `sendForm` no longer takes the public key inline.

## Verification
- `yarn build` compiles successfully.

## Notes
- No tests exist for this component, so no test updates are required.
- The EmailJS service ID, template ID, and public key are unchanged.